### PR TITLE
Feature/start game

### DIFF
--- a/client/src/components/JoinLobbyButton.jsx
+++ b/client/src/components/JoinLobbyButton.jsx
@@ -12,6 +12,7 @@ export default function JoinLobbyButton({ lobby, player, playerList, socket }) {
         playerId: player.id,
         playerName: player.name,
         socketId: socketId,
+        lobbyName: lobby.name
       });
 
       alert(response.data.message);

--- a/client/src/components/LeaveLobbyButton.jsx
+++ b/client/src/components/LeaveLobbyButton.jsx
@@ -12,6 +12,7 @@ export default function LeaveLobbyButton({ lobby, player, playerList, socket }) 
         playerId: player.id,
         playerName: player.name,
         socketId: socketId,
+        lobbyName: lobby.name
       });
 
       alert(response.data.message);

--- a/client/src/components/LobbyList.jsx
+++ b/client/src/components/LobbyList.jsx
@@ -62,14 +62,21 @@ export default function LobbyList({ player }) {
       alert(message);
     };
 
+    const handleGameStarted = ({ message }) => {
+      console.log(`gameStarted CLIENT SOCKET: ${message}`);
+      alert(message);
+    };
+
     // SOCKET EVENT LISTENERS
     socket.on('playerJoinedLobby', handlePlayerJoined);
     socket.on('playerLeftLobby', handlePlayerLeft);
+    socket.on('gameStarted', handleGameStarted);
 
     // CLEAN UP
     return () => {
       socket.off('playerJoinedLobby', handlePlayerJoined);
       socket.off('playerLeftLobby', handlePlayerLeft);
+      socket.off('gameStarted', handleGameStarted);
     };
   }, []);
 

--- a/client/src/components/StartGameButton.jsx
+++ b/client/src/components/StartGameButton.jsx
@@ -4,11 +4,20 @@ import axios from 'axios';
 
 export default function StartGameButton({ lobby, player, playerList, socket }) {
   //HANDLE EVENTS
-  const handleStartGameClick = () => {
-
+  const handleStartGameClick = async () => {
+    try {
+      const response = await axios.delete(`http://localhost:3000/lobbies/${lobby.id}`, { data:
+        {lobbyName:lobby.name}
+      });
+    } catch (error) {
+      console.error("Couldn't start game:", error);
+      alert("Failed to start the game for lobby");
+    }
   }
   return (
-    <button>
+    <button
+      onClick={handleStartGameClick}
+    >
       Start Game
     </button>
   )

--- a/server/controllers/joinLobby.js
+++ b/server/controllers/joinLobby.js
@@ -6,29 +6,39 @@ import { io } from '../index.js';
 // CONTROLLER FUNCTION
 export const joinLobby = (req, res) => {
   try {
-    const { playerId, playerName, socketId } = req.body;
+    const { lobbyName, playerId, playerName, socketId } = req.body;
     const lobbyId = req.params.id;
 
     const socket = io.of("/").sockets.get(socketId);
 
     if (socket) {
       socket.join(lobbyId);
-      console.log(`SERVER JOIN 1: Socket ${socket.id} joined lobby ${lobbyId}`);
-
-      socket.to(lobbyId).emit('playerJoinedLobby', {
-        message: `${playerName} has joined the '${lobbies[lobbyId].name}' lobby.`,
-      });
+      console.log(`SERVER JOIN 1: Socket ${socket.id} joined lobby ${lobbyName}`);
 
       lobbies[lobbyId].addPlayer(playerId, playerName);
 
+      if (lobbies[lobbyId].players.length === 3) {
+        delete lobbies[lobbyId];
+
+        socket.to(lobbyId).emit('gameStarted', {
+          message: `The game in the lobby ${lobbyName} is starting, and the lobby has been deleted`,
+        });
+
+        return res.status(200).json({ success: true, message: `You're the third player joining the ${lobbyName} lobby, which has started the game and will delete the lobby.` });
+      }
+
+      socket.to(lobbyId).emit('playerJoinedLobby', {
+        message: `${playerName} has joined the '${lobbyName}' lobby.`,
+      });
+
       io.to(lobbyId).emit('lobbyUpdated', {
-        message: `${playerName} has joined the '${lobbies[lobbyId].name}' lobby.`,
+        message: `${playerName} has joined the '${lobbyName}' lobby.`,
         players: lobbies[lobbyId].players
       });
 
-      console.log(`SERVER JOIN 2: Player ${playerName} added to lobby '${lobbies[lobbyId].name}'`);
+      console.log(`SERVER JOIN 2: Player ${playerName} added to lobby '${lobbyName}'`);
 
-      res.json({ success: true, message: `You've joined the lobby '${lobbies[lobbyId].name}'.`, lobby: lobbies[lobbyId] });
+      res.json({ success: true, message: `You've joined the lobby '${lobbyName}'.`, lobby: lobbies[lobbyId] });
     } else {
       console.log(`Socket not found for player ${playerName} with socket ID ${socketId}`);
       res.status(404).json({ error: 'Socket not found' });

--- a/server/controllers/startGame.js
+++ b/server/controllers/startGame.js
@@ -1,0 +1,26 @@
+// LOCAL IMPORTS
+import lobbies from '../dataStore.js';
+import { io } from '../index.js';
+
+// CONTROLLER FUNCTION
+export const startGame = (req, res) => {
+  try {
+    const { lobbyName } = req.body;
+    const lobbyId = req.params.id;
+
+    if (lobbies[lobbyId]) {
+
+      delete lobbies[lobbyId];
+
+      io.to(lobbyId).emit('gameStarted', { message: `The game in the ${lobbyName} lobby started, and the lobby was deleted.` });
+
+      res.status(200).json({ success: true, message: `You started a game in the ${lobbyName} lobby, and the lobby was deleted.` });
+
+    } else {
+      res.status(404).json({ error: 'Lobby not found' });
+    }
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'An error occurred while starting the game' });
+  }
+};

--- a/server/routes.js
+++ b/server/routes.js
@@ -9,6 +9,7 @@ import { getAllLobbies } from './controllers/getAllLobbies.js';
 import { getLobbyPlayers } from './controllers/getLobbyPlayers.js';
 import { joinLobby } from './controllers/joinLobby.js';
 import { leaveLobby } from './controllers/leaveLobby.js';
+import { startGame } from './controllers/startGame.js';
 
 // ROUTES
 router.post('/lobbies', createLobby);
@@ -16,5 +17,6 @@ router.get('/lobbies', getAllLobbies);
 router.get('/lobbies/:id/players', getLobbyPlayers);
 router.put('/lobbies/:id/join', joinLobby);
 router.put('/lobbies/:id/leave', leaveLobby);
+router.delete('/lobbies/:id', startGame);
 
 export default router;


### PR DESCRIPTION
## Description
This PR adds functionality to the start game button. When clicked it will notify all players in lobby and delete lobby. When a third player joins a lobby it will automatically start a game, delete the lobby, and notify all players. Finally, when the last player leaves a lobby, it will automatically delete the lobby and notify the player.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->


## Acceptance Criteria

- [x] Delete a lobby when the game starts or if it's empty.
- [x] Start the game automatically when the lobby reaches a predetermined number of players.
- [x] Notify all players in a lobby of a game starting in real-time.

<!-- Put an `x` between the brackets to mark complete (don't add spaces) e.g. -[x] -->
<!-- Include AC from the JIRA ticket https://lemon-zest.atlassian.net/jira/software/projects/UM/boards/2 -->

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓  | :sparkles: New feature     |
|     | 🎨 Style                   |
|     | :hammer: Refactoring       |
|     | :bug: Bug fix              |
|     | :link: Update dependencies |


## Mobile & Desktop Screenshots/Recordings

https://github.com/avinashi10/game-lobby-system/assets/115492619/8637b546-7402-49b2-884e-173609fa5cd1


<!-- Visual changes require screenshots -->

## What I learned
When you `emit()` data from the server, it has match the structure expected by the event listener on the front end. If they don't line up, the app won't receive what was emitted, highlighting why keeping data structure consistent is key.

## Testing steps

1.  Switch to branch `feature/start-game`
2. Run `npm start`
3. Open several browser windows at the local host indicated in terminal.
4. Create several players and leave and join lobbies. 
5. Check accuracy of alerts when clicking start game, when a third player joins a lobby, and when the last player leaves a lobby.


## What gif best describes this PR?
  ![woohoo](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdDVrd3Y3Ynp2NmtkMTN6YTNqcHliNmp0aDk5ZGRpZmFlc3RmbG15cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FlWgXEtj5aM5G/giphy.gif)
<!--
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](url)
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
